### PR TITLE
feat: establish dockerized foundation and backend runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,20 @@ Set these required values in `.env`:
 - `PGADMIN_DEFAULT_EMAIL`
 - `PGADMIN_DEFAULT_PASSWORD`
 
+Password source in this project:
+- `postgres` reads `secrets/db_password.txt` via Docker secret `db_password`.
+- `backend` (in Docker Compose) reads `DB_PASSWORD_FILE=/run/secrets/db_password` from that same secret.
+- `DB_PASSWORD` in `.env` is a fallback for non-Compose/local direct runs.
+
+If `DB_PASSWORD` and `secrets/db_password.txt` differ when not using shared-secret mode, database authentication can fail.
+
 #### 2) Generate local secrets
 ```bash
 bash scripts/generate-secrets.sh
 ```
 
 Use `bash scripts/generate-secrets.sh --force` to overwrite existing files in `secrets/`.
+If you set `DB_PASSWORD` manually for non-Compose runs, keep it aligned with `secrets/db_password.txt`.
 
 #### 3) Start the stack
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,9 @@ services:
       DB_PORT: 5432
       DB_NAME: ${DB_NAME:-career-scout}
       DB_USER: ${DB_USER:-postgres}
-      DB_PASSWORD: ${DB_PASSWORD}
+      DB_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - db_password
     ports:
       - "8000:8000"
     networks:


### PR DESCRIPTION
## Summary
- Complete Docker environment foundation with PostgreSQL, Redis, pgAdmin, and backend service in `docker-compose.yml`.
- Add backend runtime baseline with multi-stage Dockerfile (`uv` + hash-locked deps), `/api/v1/health/` endpoint, and non-root container execution.
- Finalize environment/secrets workflow (`.env.example`, `scripts/generate-secrets.sh`, `secrets/README.md`) and add root README setup/verification instructions.
- Align project workflow and naming consistency (`dev -> main` release flow, Career Scout naming updates).

## Validation
- `docker compose up -d --build` starts 4 services: `postgres`, `redis`, `pgadmin`, `backend`.
- All services report `healthy`.
- Connectivity checks pass:
  - `http://localhost:8000/api/v1/health/`
  - `http://localhost:5050`
  - Postgres reachable at `localhost:5432`
- Restart criterion verified with `docker compose down && docker compose up -d --build`.

## Included Issues
- Closes #2
- Implements #3, #4, #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive setup guide covering prerequisites, environment and secret configuration, startup procedures, service endpoint verification, and docker management commands.

* **Chores**
  * Added a backend service to the local compose configuration with health checks, port mapping, and dependency ordering for database/cache.
  * Improved configuration to allow loading the database password from a secrets file for safer deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->