### PR TITLE
Seek nitpick cleanup: signature parity and test helper dedup

### DIFF
--- a/backend/src/scrapers/seek.py
+++ b/backend/src/scrapers/seek.py
@@ -332,7 +332,6 @@ class SeekScraper(BaseScraper):
         primary_html = await self._extract_html_from_page_selectors(
             selectors=self.DESCRIPTION_HTML_SELECTORS,
             extraction_label="description_html_primary",
-            fallback_path="primary",
         )
         if primary_html:
             return primary_html
@@ -343,7 +342,6 @@ class SeekScraper(BaseScraper):
         fallback_html = await self._extract_html_from_page_selectors(
             selectors=self.DESCRIPTION_HTML_FALLBACK_SELECTORS,
             extraction_label="description_html_fallback",
-            fallback_path="fallback",
         )
         if fallback_html:
             return fallback_html
@@ -357,7 +355,6 @@ class SeekScraper(BaseScraper):
         self,
         selectors: tuple[str, ...],
         extraction_label: str,
-        fallback_path: str,
     ) -> str | None:
         """Extract raw outer HTML from first matching selector."""
         if self.page is None:
@@ -375,7 +372,6 @@ class SeekScraper(BaseScraper):
                         scraper=self.__class__.__name__,
                         selector=selector,
                         extraction_label=extraction_label,
-                        fallback_path=fallback_path,
                     ).info("Extracted Seek raw description HTML")
                     return raw_html.strip()
             except PlaywrightTimeoutError:
@@ -383,7 +379,6 @@ class SeekScraper(BaseScraper):
                     scraper=self.__class__.__name__,
                     selector=selector,
                     extraction_label=extraction_label,
-                    fallback_path=fallback_path,
                 ).debug("Seek raw HTML extraction timed out")
                 continue
             except Exception as exc:
@@ -391,7 +386,6 @@ class SeekScraper(BaseScraper):
                     scraper=self.__class__.__name__,
                     selector=selector,
                     extraction_label=extraction_label,
-                    fallback_path=fallback_path,
                     error=str(exc),
                 ).debug("Seek raw HTML extraction failed for selector")
                 continue
@@ -418,13 +412,6 @@ class SeekScraper(BaseScraper):
             if hint in lowered:
                 return hint.title()
         return None
-
-    async def _extract_salary_range(self) -> dict[str, Any] | None:
-        """Extract salary range from detail page salary blocks."""
-        salary_text = await self._extract_text_from_page_selectors(
-            self.SALARY_SELECTORS
-        )
-        return self._extract_salary_range_from_text(salary_text)
 
     def _extract_salary_range_from_text(
         self,

--- a/backend/tests/tasks/test_scraper_tasks.py
+++ b/backend/tests/tasks/test_scraper_tasks.py
@@ -54,17 +54,18 @@ class DummySessionContext:
         del exc_type, exc, tb
 
 
-def make_linkedin_scraper_double(
+def make_scraper_double(
     scraped_jobs: list[dict[str, Any]],
+    class_name: str,
 ) -> type:
-    """Build a lightweight LinkedIn scraper double for a fixed payload."""
+    """Build a lightweight scraper double for a fixed payload."""
 
-    class FakeLinkedInScraper:
+    class FakeScraper:
         def __init__(self, headless: bool, rate_limit_seconds: float) -> None:
             self.headless = headless
             self.rate_limit_seconds = rate_limit_seconds
 
-        async def __aenter__(self) -> "FakeLinkedInScraper":
+        async def __aenter__(self) -> "FakeScraper":
             return self
 
         async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
@@ -79,35 +80,8 @@ def make_linkedin_scraper_double(
             del query, location, limit
             return scraped_jobs
 
-    return FakeLinkedInScraper
-
-
-def make_seek_scraper_double(
-    scraped_jobs: list[dict[str, Any]],
-) -> type:
-    """Build a lightweight Seek scraper double for a fixed payload."""
-
-    class FakeSeekScraper:
-        def __init__(self, headless: bool, rate_limit_seconds: float) -> None:
-            self.headless = headless
-            self.rate_limit_seconds = rate_limit_seconds
-
-        async def __aenter__(self) -> "FakeSeekScraper":
-            return self
-
-        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
-            del exc_type, exc, tb
-
-        async def scrape_jobs(
-            self,
-            query: str,
-            location: str,
-            limit: int,
-        ) -> list[dict[str, Any]]:
-            del query, location, limit
-            return scraped_jobs
-
-    return FakeSeekScraper
+    FakeScraper.__name__ = class_name
+    return FakeScraper
 
 
 SCRAPE_TASK_RUN = scraper_tasks.scrape_linkedin_jobs.run.__func__  # type: ignore[attr-defined]
@@ -626,7 +600,7 @@ def test_run_linkedin_scrape_and_persist_maps_metadata_and_persists_fields(
     monkeypatch.setattr(
         scraper_tasks,
         "LinkedInScraper",
-        make_linkedin_scraper_double(fake_scraped_jobs),
+        make_scraper_double(fake_scraped_jobs, class_name="FakeLinkedInScraper"),
     )
     monkeypatch.setattr(scraper_tasks, "get_session", lambda: DummySessionContext())
     monkeypatch.setattr(scraper_tasks, "JobRepository", FakeJobRepository)
@@ -694,7 +668,7 @@ def test_run_seek_scrape_and_persist_maps_metadata_and_persists_fields(
     monkeypatch.setattr(
         scraper_tasks,
         "SeekScraper",
-        make_seek_scraper_double(fake_scraped_jobs),
+        make_scraper_double(fake_scraped_jobs, class_name="FakeSeekScraper"),
     )
     monkeypatch.setattr(scraper_tasks, "get_session", lambda: DummySessionContext())
     monkeypatch.setattr(scraper_tasks, "JobRepository", FakeJobRepository)
@@ -764,7 +738,7 @@ def test_run_seek_scrape_and_persist_updates_empty_fields_with_meaningful_values
     monkeypatch.setattr(
         scraper_tasks,
         "SeekScraper",
-        make_seek_scraper_double(fake_scraped_jobs),
+        make_scraper_double(fake_scraped_jobs, class_name="FakeSeekScraper"),
     )
     monkeypatch.setattr(scraper_tasks, "get_session", lambda: DummySessionContext())
     monkeypatch.setattr(scraper_tasks, "JobRepository", FakeJobRepository)
@@ -833,7 +807,7 @@ def test_run_seek_scrape_and_persist_skips_empty_values_for_non_empty_existing_f
     monkeypatch.setattr(
         scraper_tasks,
         "SeekScraper",
-        make_seek_scraper_double(fake_scraped_jobs),
+        make_scraper_double(fake_scraped_jobs, class_name="FakeSeekScraper"),
     )
     monkeypatch.setattr(scraper_tasks, "get_session", lambda: DummySessionContext())
     monkeypatch.setattr(scraper_tasks, "JobRepository", FakeJobRepository)
@@ -900,7 +874,7 @@ def test_run_seek_scrape_and_persist_does_not_overwrite_existing_enriched_fields
     monkeypatch.setattr(
         scraper_tasks,
         "SeekScraper",
-        make_seek_scraper_double(fake_scraped_jobs),
+        make_scraper_double(fake_scraped_jobs, class_name="FakeSeekScraper"),
     )
     monkeypatch.setattr(scraper_tasks, "get_session", lambda: DummySessionContext())
     monkeypatch.setattr(scraper_tasks, "JobRepository", FakeJobRepository)
@@ -1511,7 +1485,7 @@ def test_run_linkedin_scrape_and_persist_does_not_count_none_updates(
     monkeypatch.setattr(
         scraper_tasks,
         "LinkedInScraper",
-        make_linkedin_scraper_double(fake_scraped_jobs),
+        make_scraper_double(fake_scraped_jobs, class_name="FakeLinkedInScraper"),
     )
     monkeypatch.setattr(scraper_tasks, "get_session", lambda: DummySessionContext())
     monkeypatch.setattr(scraper_tasks, "JobRepository", FakeJobRepository)
@@ -1567,7 +1541,7 @@ def test_run_linkedin_scrape_and_persist_counts_real_updates(
     monkeypatch.setattr(
         scraper_tasks,
         "LinkedInScraper",
-        make_linkedin_scraper_double(fake_scraped_jobs),
+        make_scraper_double(fake_scraped_jobs, class_name="FakeLinkedInScraper"),
     )
     monkeypatch.setattr(scraper_tasks, "get_session", lambda: DummySessionContext())
     monkeypatch.setattr(scraper_tasks, "JobRepository", FakeJobRepository)


### PR DESCRIPTION
## Summary
- Remove `fallback_path` argument from `SeekScraper._extract_html_from_page_selectors` to align helper signatures with LinkedIn scraper and rely on `extraction_label` for context.
- Remove unused private helper `_extract_salary_range` from Seek scraper (dead code).
- Consolidate duplicated scraper doubles in task tests into a single `make_scraper_double(...)` factory and update all call sites.

## Validation
- `pytest backend/tests/scrapers/test_seek_scraper.py`
- `pytest backend/tests/tasks/test_scraper_tasks.py`

Both suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal salary extraction logic in the Seek job scraper for improved code efficiency.
  * Streamlined HTML extraction process by removing unnecessary fallback tracking mechanisms.

* **Tests**
  * Consolidated test helper functions for better code reusability across multiple test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->